### PR TITLE
Include profile sources in alias

### DIFF
--- a/src/depify/project.clj
+++ b/src/depify/project.clj
@@ -109,7 +109,10 @@
            (update-in [:aliases pk] (fnil merge {}) (-> opts :aliases :run))
            
            (-> opts :deps)
-           (update-in [:aliases pk :extra-deps] (fnil merge {}) (-> opts :deps)))
+           (update-in [:aliases pk :extra-deps] (fnil merge {}) (-> opts :deps))
+
+           (-> opts :paths)
+           (update-in [:aliases pk :extra-paths] (fnil into []) (-> opts :paths)))
          m)))
    ctx
    v))

--- a/src/depify/project.clj
+++ b/src/depify/project.clj
@@ -107,7 +107,7 @@
          (cond-> m
            (-> opts :aliases :run)
            (update-in [:aliases pk] (fnil merge {}) (-> opts :aliases :run))
-           
+
            (-> opts :deps)
            (update-in [:aliases pk :extra-deps] (fnil merge {}) (-> opts :deps))
 
@@ -133,10 +133,10 @@
 
          [([(m :guard map?)] :seq)]
          m
-         
+
          [([(d :guard (comp vector? first)) & r] :seq)]
          (recur (update ctx :dependencies (fnil into []) d) r)
-             
+
          :else ctx))
 
 (defn read-project
@@ -150,7 +150,7 @@
 
          [([k v & r] :seq)]
          (recur (assoc ctx k v) r)
-         
+
          :else ctx))
 
 (defn read-prj
@@ -159,10 +159,10 @@
   (match [forms]
          [([(_ :guard map?)] :seq)]
          (read-pprint ctx forms)
-         
+
          [([(_ :guard (comp vector? first)) & _] :seq)]
          (read-pprint ctx forms)
-         
+
          [([(['def _ _] :seq) & _] :seq)]
          (read-project ctx forms)
 
@@ -196,7 +196,10 @@
                          (-> ctx
                              (dissoc k)
                              (handle-key k v))))
-                     (merge-with merge default-deps-template (dissoc ctx :aliases))))]
+                     (assoc (merge-with merge default-deps-template (dissoc ctx :aliases))
+                       :paths ["src" "resources"])
+
+                     ))]
     (select-keys result [:aliases :deps :paths :mvn/repos])))
 
 (defn -main [& args]

--- a/test/depify/project_test.clj
+++ b/test/depify/project_test.clj
@@ -92,14 +92,17 @@
                  :main super-dooper.core
                  :dependencies [[ding/dong "1.0"]]
                  :profiles {:dev {:dependencies [[tick/tock "1.0"]]
-                                  :jvm-opts ["-XX:+CrashAndBurn"]}}))
+                                  :jvm-opts ["-XX:+CrashAndBurn"]
+                                  :source-paths ["resources"]
+                                  :resource-paths ["more-resources"]}}))
         answer '{:aliases
                  {:run
                   {:jvm-opts ["-XX:+EnormousBiceps"],
                    :main-opts ["-m" "super-dooper.core"]},
                   :dev
                   {:jvm-opts ["-XX:+CrashAndBurn"],
-                   :extra-deps {tick/tock {:mvn/version "1.0"}}}},
+                   :extra-deps {tick/tock {:mvn/version "1.0"}}
+                   :extra-paths ["src" "resources" "more-resources"]}},
                  :deps {ding/dong {:mvn/version "1.0"}}} ]
     (compare-helper form answer)))
 


### PR DESCRIPTION
Aliases created from lein profiles were missing `:extra-paths`.